### PR TITLE
Remove duplicate &optional keyword to avoid "invalid function" error

### DIFF
--- a/jsfmt.el
+++ b/jsfmt.el
@@ -88,7 +88,7 @@ buffer."
              (t
               (error "invalid rcs patch or internal error in jsfmt--apply-rcs-patch")))))))))
 
-(defun run-jsfmt (&optional save &optional ast)
+(defun run-jsfmt (&optional save ast)
   "Formats the current buffer according to the jsfmt tool."
   (interactive)
   (let ((tmpfile (make-temp-file "jsfmt" nil (if ast


### PR DESCRIPTION
The following is my environment:
```
GNU Emacs 26.1 (build 1, x86_64-apple-darwin17.5.0, NS appkit-1561.40 Version 10.13.4 (Build 17E202)) of 2018-06-19
```
Everytime I call ```jsfmt-before-save``` function, I get this error:
```
Debugger entered--Lisp error: (invalid-function (lambda (&optional save &optional ast) "Formats the current buffer according to the jsfmt tool." (interactive) (let ((tmpfile (make-temp-file "jsfmt" nil (if ast ".ast" ".js"))) (patchbuf (get-buffer-create "*Jsfmt patch*")) (errbuf (get-buffer-create "*Jsfmt Errors*")) (coding-system-for-read 'utf-8) (coding-system-for-write 'utf-8)) (with-current-buffer errbuf (setq buffer-read-only nil) (erase-buffer)) (with-current-buffer patchbuf (erase-buffer)) (write-region nil nil tmpfile) (if save (if ast (setq success (zerop (call-process jsfmt-command nil errbuf nil "--save-ast" "--write" tmpfile))) (setq success (zerop (call-process jsfmt-command nil errbuf nil "--write" tmpfile)))) (if ast (setq success (zerop (call-process jsfmt-command nil errbuf nil "--ast" "--write" tmpfile))) (setq success nil)) (setq success nil)) (if 'success (if (zerop (call-process-region (point-min) (point-max) "diff" nil patchbuf nil "-n" "-" tmpfile)) (progn (kill-buffer errbuf) (message "Buffer is already jsfmted")) (jsfmt--apply-rcs-patch patchbuf) (kill-buffer errbuf) (message "Applied jsfmt")) (message "Could not apply jsfmt. Check errors for details") (jsfmt--process-errors (buffer-file-name) tmpfile errbuf)) (kill-buffer patchbuf) (delete-file tmpfile))))
  run-jsfmt(t nil)
  jsfmt()
  (progn (jsfmt))
  (if (memq major-mode '(js-mode js2-mode js3-mode)) (progn (jsfmt)))
  jsfmt-before-save()
  run-hooks(before-save-hook)
  basic-save-buffer(t)
  save-buffer(1)
  funcall-interactively(save-buffer 1)
  call-interactively(save-buffer nil nil)
  command-execute(save-buffer)
```
After removing the duplicated ```&optional``` keyword, it works fine.